### PR TITLE
Add support for setting FontConfig.Name

### DIFF
--- a/FontConfig.go
+++ b/FontConfig.go
@@ -90,6 +90,19 @@ func (config FontConfig) SetMergeMode(value bool) {
 	}
 }
 
+// SetName sets a short display name for a font, for diagnostic purposes.
+// If the FontConfig does not provide a name, one will be synthesized for
+// fonts which are added from files.  When adding fonts from memory, this
+// method can be used to provide a name.
+// The name will be truncated if it is longer than the limit supported by imgui.
+func (config FontConfig) SetName(name string) {
+	if config != DefaultFontConfig {
+		nameArg, nameFin := wrapString(name)
+		defer nameFin()
+		C.iggFontConfigSetName(config.handle(), nameArg)
+	}
+}
+
 // getFontDataOwnedByAtlas gets the current ownership status of the font data.
 func (config FontConfig) getFontDataOwnedByAtlas() bool {
 	if config != DefaultFontConfig {

--- a/wrapper/FontConfig.cpp
+++ b/wrapper/FontConfig.cpp
@@ -56,6 +56,14 @@ void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value)
    fontConfig->MergeMode = value;
 }
 
+void iggFontConfigSetName(IggFontConfig handle, char const *value)
+{
+   ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);
+   const size_t bufSize = sizeof(fontConfig->Name);
+   strncpy(fontConfig->Name, value, bufSize - 1);
+   fontConfig->Name[bufSize - 1] = '\0';
+}
+
 int iggFontConfigGetFontDataOwnedByAtlas(IggFontConfig handle)
 {
    ImFontConfig *fontConfig = reinterpret_cast<ImFontConfig *>(handle);

--- a/wrapper/FontConfig.h
+++ b/wrapper/FontConfig.h
@@ -16,6 +16,7 @@ extern void iggFontConfigSetPixelSnapH(IggFontConfig handle, IggBool value);
 extern void iggFontConfigSetGlyphMinAdvanceX(IggFontConfig handle, float value);
 extern void iggFontConfigSetGlyphMaxAdvanceX(IggFontConfig handle, float value);
 extern void iggFontConfigSetMergeMode(IggFontConfig handle, IggBool value);
+extern void iggFontConfigSetName(IggFontConfig handle, char const *value);
 extern int iggFontConfigGetFontDataOwnedByAtlas(IggFontConfig handle);
 
 #ifdef __cplusplus


### PR DESCRIPTION
IMGUI will synthesize a diagnostic name for fonts added from files
(eg "foo.ttf, 16px") if there isn't a name provided in the FontConfig.

There isn't an equivalent synthetic name for fonts added from memory,
so enable the name to be set on the FontConfig.

The names are visible in the Dear Imgui Demo window
under Configuration > Style, in the Fonts drop-list.